### PR TITLE
Benchmark composer cache in tests.yml

### DIFF
--- a/.github/actions/setup-php-project/action.yml
+++ b/.github/actions/setup-php-project/action.yml
@@ -53,6 +53,19 @@ runs:
       shell: bash
       run: composer config version "${{ inputs.framework-version }}"
 
+    - name: Get composer cache directory
+      id: composer-cache
+      shell: bash
+      run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+    - name: Cache composer packages
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: composer-${{ runner.os }}-${{ hashFiles('composer.json') }}
+        restore-keys: |
+          composer-${{ runner.os }}-
+
     - name: Install dependencies
       uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,12 +43,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.3, 8.4, 8.5]
-        phpunit: ['11.5.50', '12.5.8', '13.0.3']
+        php: [8.4]
+        phpunit: ['12.5.8']
         stability: [prefer-lowest, prefer-stable]
-        exclude:
-          - php: 8.3
-            phpunit: '13.0.3'
 
     name: PHP ${{ matrix.php }} - PHPUnit ${{ matrix.phpunit }} - ${{ matrix.stability }}
 
@@ -93,12 +90,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.3, 8.4, 8.5]
-        phpunit: ['11.5.50', '12.5.8', '13.0.3']
+        php: [8.4]
+        phpunit: ['12.5.8']
         stability: [prefer-lowest, prefer-stable]
-        exclude:
-          - php: 8.3
-            phpunit: '13.0.3'
 
     name: PHP ${{ matrix.php }} - PHPUnit ${{ matrix.phpunit }} - ${{ matrix.stability }} - Windows
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,9 +43,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.4]
-        phpunit: ['12.5.8']
+        php: [8.3, 8.4, 8.5]
+        phpunit: ['11.5.50', '12.5.8', '13.0.3']
         stability: [prefer-lowest, prefer-stable]
+        exclude:
+          - php: 8.3
+            phpunit: '13.0.3'
 
     name: PHP ${{ matrix.php }} - PHPUnit ${{ matrix.phpunit }} - ${{ matrix.stability }}
 
@@ -90,9 +93,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.4]
-        phpunit: ['12.5.8']
+        php: [8.3, 8.4, 8.5]
+        phpunit: ['11.5.50', '12.5.8', '13.0.3']
         stability: [prefer-lowest, prefer-stable]
+        exclude:
+          - php: 8.3
+            phpunit: '13.0.3'
 
     name: PHP ${{ matrix.php }} - PHPUnit ${{ matrix.phpunit }} - ${{ matrix.stability }} - Windows
 

--- a/src/Illuminate/Auth/Access/Gate.php
+++ b/src/Illuminate/Auth/Access/Gate.php
@@ -858,7 +858,7 @@ class Gate implements GateContract
      */
     public function forUser($user)
     {
-        return new static(
+        $gate = new static(
             $this->container,
             fn () => $user,
             $this->abilities,
@@ -867,6 +867,10 @@ class Gate implements GateContract
             $this->afterCallbacks,
             $this->guessPolicyNamesUsingCallback,
         );
+
+        $gate->defaultDenialResponse = $this->defaultDenialResponse;
+
+        return $gate;
     }
 
     /**

--- a/src/Illuminate/Collections/LazyCollection.php
+++ b/src/Illuminate/Collections/LazyCollection.php
@@ -517,7 +517,9 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
     {
         return new static(function () {
             foreach ($this as $key => $value) {
-                yield $value => $key;
+                if (is_string($value) || is_int($value)) {
+                    yield $value => $key;
+                }
             }
         });
     }

--- a/src/Illuminate/Foundation/DevCommands.php
+++ b/src/Illuminate/Foundation/DevCommands.php
@@ -55,7 +55,7 @@ class DevCommands
             return;
         }
 
-        self::artisan('serve --host=localhost', 'server');
+        self::artisan('serve', 'server');
         self::artisan('queue:listen --tries=1 --timeout=0', 'queue');
 
         if (function_exists('pcntl_fork')) {

--- a/src/Illuminate/Http/Concerns/InteractsWithInput.php
+++ b/src/Illuminate/Http/Concerns/InteractsWithInput.php
@@ -86,7 +86,7 @@ trait InteractsWithInput
      */
     public function all($keys = null)
     {
-        $input = array_replace_recursive($this->input(), $this->allFiles());
+        $input = array_replace_recursive($this->allFiles(), $this->input());
 
         if (! $keys) {
             return $input;

--- a/src/Illuminate/Notifications/SendQueuedNotifications.php
+++ b/src/Illuminate/Notifications/SendQueuedNotifications.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Queue\Attributes\Backoff;
 use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
+use Illuminate\Queue\Attributes\FailOnTimeout;
 use Illuminate\Queue\Attributes\MaxExceptions;
 use Illuminate\Queue\Attributes\ReadsQueueAttributes;
 use Illuminate\Queue\Attributes\Timeout;
@@ -77,6 +78,13 @@ class SendQueuedNotifications implements ShouldQueue
     public bool $deleteWhenMissingModels = false;
 
     /**
+     * Indicates if the job should be marked as failed on timeout.
+     *
+     * @var bool
+     */
+    public $failOnTimeout = false;
+
+    /**
      * Create a new job instance.
      *
      * @param  \Illuminate\Notifications\Notifiable|\Illuminate\Support\Collection  $notifiables
@@ -92,6 +100,7 @@ class SendQueuedNotifications implements ShouldQueue
         $this->timeout = $this->getAttributeValue($notification, Timeout::class, 'timeout');
         $this->maxExceptions = $this->getAttributeValue($notification, MaxExceptions::class, 'maxExceptions');
         $this->deleteWhenMissingModels = $this->getAttributeValue($notification, DeleteWhenMissingModels::class, 'deleteWhenMissingModels') ?? false;
+        $this->failOnTimeout = $this->getAttributeValue($notification, FailOnTimeout::class, 'failOnTimeout') ?? false;
 
         if ($notification instanceof ShouldQueueAfterCommit) {
             $this->afterCommit = true;

--- a/tests/AfterEachTestSubscriber.php
+++ b/tests/AfterEachTestSubscriber.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Illuminate\Tests;
 
+use Carbon\CarbonImmutable;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Lottery;
+use Illuminate\Support\Once;
+use Illuminate\Support\Sleep;
+use Illuminate\Support\Str;
 use PHPUnit\Event\Test\Finished;
 use PHPUnit\Event\Test\FinishedSubscriber;
 
@@ -17,6 +22,12 @@ final class AfterEachTestSubscriber implements FinishedSubscriber
         }
 
         Carbon::setTestNow();
+        CarbonImmutable::setTestNow();
         date_default_timezone_set('UTC');
+
+        Str::resetFactoryState();
+        Sleep::fake(false);
+        Once::flush();
+        Lottery::determineResultNormally();
     }
 }

--- a/tests/Auth/AuthAccessGateTest.php
+++ b/tests/Auth/AuthAccessGateTest.php
@@ -638,6 +638,20 @@ class AuthAccessGateTest extends TestCase
         $this->assertSame(3, $counter);
     }
 
+    public function testForUserMethodPreservesDefaultDenialResponse()
+    {
+        $gate = $this->getBasicGate();
+
+        $gate->define('view-secret', fn () => false);
+        $gate->defaultDenialResponse(Response::denyAsNotFound('Not found'));
+
+        $response = $gate->forUser((object) ['id' => 2])->inspect('view-secret');
+
+        $this->assertTrue($response->denied());
+        $this->assertSame('Not found', $response->message());
+        $this->assertSame(404, $response->status());
+    }
+
     #[DataProvider('notCallableDataProvider')]
     public function testDefineSecondParameterShouldBeStringOrCallable($callback)
     {

--- a/tests/Cache/CacheDynamoDbStoreTest.php
+++ b/tests/Cache/CacheDynamoDbStoreTest.php
@@ -23,8 +23,8 @@ class CacheDynamoDbStoreTest extends TestCase
                 && str_contains($dynamo->args['UpdateExpression'], 'SET')
         );
 
-        $this->assertTrue(
-            $ttl === $dynamo->args['ExpressionAttributeValues'][':expiry']['N']
+        $this->assertSame(
+            $ttl, $dynamo->args['ExpressionAttributeValues'][':expiry']['N']
             - $dynamo->args['ExpressionAttributeValues'][':now']['N']
         );
     }

--- a/tests/Console/CommandMutexTest.php
+++ b/tests/Console/CommandMutexTest.php
@@ -26,8 +26,6 @@ class CommandMutexTest extends TestCase
      */
     protected $commandMutex;
 
-    /** {@inheritdoc} */
-    #[\Override]
     protected function setUp(): void
     {
         $this->command = new class extends Command implements Isolatable
@@ -47,8 +45,6 @@ class CommandMutexTest extends TestCase
         $this->command->setLaravel($app);
     }
 
-    /** {@inheritdoc} */
-    #[\Override]
     protected function tearDown(): void
     {
         $this->tearDownTheTestEnvironmentUsingMockery();

--- a/tests/Database/DatabaseConcernsHasAttributesTest.php
+++ b/tests/Database/DatabaseConcernsHasAttributesTest.php
@@ -48,7 +48,7 @@ class DatabaseConcernsHasAttributesTest extends TestCase
         $instance = new HasAttributesWithArrayCast();
         $this->assertEquals(['foo' => null], $instance->attributesToArray());
 
-        $this->assertTrue(json_last_error() === JSON_ERROR_NONE);
+        $this->assertSame(json_last_error(), JSON_ERROR_NONE);
     }
 
     public function testUnsettingCachedAttribute()

--- a/tests/Database/DatabaseEloquentModelTest.php
+++ b/tests/Database/DatabaseEloquentModelTest.php
@@ -3822,7 +3822,7 @@ class DatabaseEloquentModelTest extends TestCase
 
         // Simulate a JSON error
         json_decode('{');
-        $this->assertTrue(json_last_error() !== JSON_ERROR_NONE);
+        $this->assertNotSame(json_last_error(), JSON_ERROR_NONE);
 
         $this->assertSame('{"name":"Mateus"}', $user->toJson(JSON_THROW_ON_ERROR));
     }

--- a/tests/Database/DatabaseMigrationCreatorTest.php
+++ b/tests/Database/DatabaseMigrationCreatorTest.php
@@ -109,7 +109,6 @@ class DatabaseMigrationCreatorTest extends TestCase
             $this->assertSame($path.'/2026_07_13_144122_create_bs_table.php', $first);
             $this->assertSame($path.'/2026_07_13_144123_create_as_table.php', $second);
         } finally {
-            Carbon::setTestNow();
             $files->deleteDirectory($path);
         }
     }

--- a/tests/Foundation/FoundationDevCommandsTest.php
+++ b/tests/Foundation/FoundationDevCommandsTest.php
@@ -302,6 +302,7 @@ class FoundationDevCommandsTest extends TestCase
 
         $names = array_column($commands, 'name');
         $this->assertContains('server', $names);
+        $this->assertSame('php artisan serve', collect($commands)->firstWhere('name', 'server')['command']);
         $this->assertContains('queue', $names);
         $this->assertContains('logs', $names);
         $this->assertContains('vite', $names);

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -1368,6 +1368,16 @@ class HttpRequestTest extends TestCase
         $this->assertEquals(['foo' => ['bar' => 'baz', 'photo' => $file], 'boom' => 'breeze'], $request->all());
     }
 
+    public function testAllInputPrefersInputOverFilesForCollidingKeys()
+    {
+        $file = new SymfonyUploadedFile(__FILE__, 'email.txt');
+        $request = Request::create('/', 'POST', ['email' => 'taylor@laravel.com'], [], ['email' => $file]);
+
+        $this->assertSame(['email' => 'taylor@laravel.com'], $request->all());
+        $this->assertSame(['email' => 'taylor@laravel.com'], $request->only('email'));
+        $this->assertInstanceOf(UploadedFile::class, $request->file('email'));
+    }
+
     public function testAllInputReturnsInputAfterReplace()
     {
         $request = Request::create('/?boom=breeze', 'GET', ['foo' => ['bar' => 'baz']]);
@@ -1914,6 +1924,34 @@ class HttpRequestTest extends TestCase
         $this->assertNull($request->undefined);
         $this->assertFalse(isset($request->undefined));
         $this->assertEmpty($request->undefined);
+    }
+
+    public function testMagicMethodsPreferInputOverFilesForCollidingKeys()
+    {
+        $file = new SymfonyUploadedFile(__FILE__, 'email.txt');
+        $request = Request::create('/', 'POST', ['email' => 'taylor@laravel.com'], [], ['email' => $file]);
+
+        $this->assertSame('taylor@laravel.com', $request->email);
+        $this->assertSame('taylor@laravel.com', $request['email']);
+    }
+
+    public function testMagicMethodsMergeNestedInputAndFilesWhilePreferringInput()
+    {
+        $avatar = new SymfonyUploadedFile(__FILE__, 'avatar.jpg');
+        $collision = new SymfonyUploadedFile(__FILE__, 'name.txt');
+        $request = Request::create('/', 'POST', [
+            'profile' => ['name' => 'Taylor'],
+        ], [], [
+            'profile' => ['name' => $collision, 'avatar' => $avatar],
+        ]);
+
+        $expected = [
+            'name' => 'Taylor',
+            'avatar' => $request->file('profile.avatar'),
+        ];
+
+        $this->assertSame($expected, $request->profile);
+        $this->assertSame(['profile' => $expected], $request->all());
     }
 
     public function testHttpRequestFlashCallsSessionFlashInputWithInputData()

--- a/tests/Http/HttpRequestTest.php
+++ b/tests/Http/HttpRequestTest.php
@@ -2004,7 +2004,7 @@ class HttpRequestTest extends TestCase
 
         Request::create('', 'GET')->json();
 
-        $this->assertTrue(json_last_error() === JSON_ERROR_NONE);
+        $this->assertSame(json_last_error(), JSON_ERROR_NONE);
     }
 
     public function testItClampsValues()

--- a/tests/Http/JsonResourceTest.php
+++ b/tests/Http/JsonResourceTest.php
@@ -42,7 +42,7 @@ class JsonResourceTest extends TestCase
 
         // Simulate a JSON error
         json_decode('{');
-        $this->assertTrue(json_last_error() !== JSON_ERROR_NONE);
+        $this->assertNotSame(json_last_error(), JSON_ERROR_NONE);
 
         $this->assertSame('{"foo":"bar"}', $resource->toJson(JSON_THROW_ON_ERROR));
     }

--- a/tests/Image/ImageManagerTest.php
+++ b/tests/Image/ImageManagerTest.php
@@ -212,7 +212,7 @@ class ImageManagerTest extends TestCase
         $image = $manager->fromUpload($file);
 
         $this->assertInstanceOf(Image::class, $image);
-        $this->assertSame(file_get_contents($file->getRealPath()), $image->toBytes());
+        $this->assertStringEqualsFile($file->getRealPath(), $image->toBytes());
         $this->assertSame($file, $image->file());
     }
 

--- a/tests/Integration/Cache/FailoverStoreTest.php
+++ b/tests/Integration/Cache/FailoverStoreTest.php
@@ -12,7 +12,6 @@ use Orchestra\Testbench\TestCase;
 #[WithConfig('cache.stores.array.serialize', false)]
 class FailoverStoreTest extends TestCase
 {
-    #[\Override]
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/Integration/Cache/MemoizedStoreTest.php
+++ b/tests/Integration/Cache/MemoizedStoreTest.php
@@ -28,8 +28,6 @@ class MemoizedStoreTest extends TestCase
 {
     use InteractsWithRedis;
 
-    /** {@inheritdoc} */
-    #[\Override]
     protected function setUp(): void
     {
         $this->afterApplicationCreated(function () {

--- a/tests/Integration/Cache/RedisStoreTest.php
+++ b/tests/Integration/Cache/RedisStoreTest.php
@@ -19,8 +19,6 @@ class RedisStoreTest extends TestCase
 {
     use InteractsWithRedis;
 
-    /** {@inheritdoc} */
-    #[\Override]
     protected function setUp(): void
     {
         $this->afterApplicationCreated(function () {

--- a/tests/Integration/Database/EloquentUniqueStringPrimaryKeysTest.php
+++ b/tests/Integration/Database/EloquentUniqueStringPrimaryKeysTest.php
@@ -69,7 +69,7 @@ class EloquentUniqueStringPrimaryKeysTest extends DatabaseTestCase
     {
         $user = ModelWithoutUuidPrimaryKey::create();
 
-        $this->assertTrue(is_int($user->id));
+        $this->assertIsInt($user->id);
         $this->assertTrue(Str::isUuid($user->foo));
         $this->assertTrue(Str::isUuid($user->bar));
     }
@@ -109,7 +109,7 @@ class EloquentUniqueStringPrimaryKeysTest extends DatabaseTestCase
 
         $user->saveQuietly();
 
-        $this->assertTrue(is_int($user->id));
+        $this->assertIsInt($user->id);
         $this->assertTrue(Str::isUuid($user->foo));
         $this->assertTrue(Str::isUuid($user->bar));
     }

--- a/tests/Integration/Database/SchemaBuilderTest.php
+++ b/tests/Integration/Database/SchemaBuilderTest.php
@@ -379,7 +379,7 @@ class SchemaBuilderTest extends DatabaseTestCase
         $columns = Schema::getColumns('foo');
 
         $this->assertCount(1, $columns);
-        $this->assertTrue($columns[0]['name'] === 'bar');
+        $this->assertSame($columns[0]['name'], 'bar');
     }
 
     public function testGetIndexes()

--- a/tests/Integration/Database/Sqlite/Console/MigrateFreshCommandWithJournalModeWalTest.php
+++ b/tests/Integration/Database/Sqlite/Console/MigrateFreshCommandWithJournalModeWalTest.php
@@ -16,8 +16,6 @@ use function Orchestra\Testbench\default_skeleton_path;
 #[WithConfig('database.connections.sqlite.journal_mode', 'wal')]
 class MigrateFreshCommandWithJournalModeWalTest extends DatabaseTestCase
 {
-    /** {@inheritDoc} */
-    #[\Override]
     protected function setUp(): void
     {
         $files = new Filesystem;

--- a/tests/Integration/Foundation/Console/ConfigPublishCommandTest.php
+++ b/tests/Integration/Foundation/Console/ConfigPublishCommandTest.php
@@ -18,7 +18,6 @@ class ConfigPublishCommandTest extends TestCase
         'config-stubs/*.php',
     ];
 
-    #[\Override]
     protected function setUp(): void
     {
         $files = new Filesystem();

--- a/tests/Integration/Http/Resources/JsonApi/TestCase.php
+++ b/tests/Integration/Http/Resources/JsonApi/TestCase.php
@@ -18,8 +18,6 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
 {
     use LazilyRefreshDatabase;
 
-    /** {@inheritdoc} */
-    #[\Override]
     protected function setUp(): void
     {
         Model::shouldBeStrict(true);

--- a/tests/Integration/Log/ContextTest.php
+++ b/tests/Integration/Log/ContextTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Log;
+namespace Illuminate\Tests\Integration\Log;
 
 use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler;
@@ -152,8 +152,8 @@ class ContextTest extends TestCase
                 'array' => 'a:3:{i:0;i:1;i:1;i:2;i:2;i:3;}',
                 'hash' => 'a:1:{s:3:"foo";s:3:"bar";}',
                 'object' => 'O:8:"stdClass":1:{s:3:"foo";s:3:"bar";}',
-                'enum' => 'E:31:"Illuminate\Tests\Log\Suit:Clubs";',
-                'backed_enum' => 'E:43:"Illuminate\Tests\Log\StringBackedSuit:Clubs";',
+                'enum' => 'E:43:"Illuminate\Tests\Integration\Log\Suit:Clubs";',
+                'backed_enum' => 'E:55:"Illuminate\Tests\Integration\Log\StringBackedSuit:Clubs";',
             ],
             'hidden' => [
                 'number' => 'i:55;',

--- a/tests/Integration/Log/ContextTest.php
+++ b/tests/Integration/Log/ContextTest.php
@@ -22,7 +22,6 @@ class ContextTest extends TestCase
 {
     use LazilyRefreshDatabase;
 
-    #[\Override]
     protected function tearDown(): void
     {
         MyAddContextProcessor::$wasConstructed = false;

--- a/tests/Integration/Log/JsonFormatterTest.php
+++ b/tests/Integration/Log/JsonFormatterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Log;
+namespace Illuminate\Tests\Integration\Log;
 
 use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler as ExceptionHandlerContract;

--- a/tests/Integration/Log/JsonFormatterTest.php
+++ b/tests/Integration/Log/JsonFormatterTest.php
@@ -17,7 +17,6 @@ use Throwable;
 
 final class JsonFormatterTest extends TestCase
 {
-    #[\Override]
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/Integration/Log/LogManagerTest.php
+++ b/tests/Integration/Log/LogManagerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Log;
+namespace Illuminate\Tests\Integration\Log;
 
 use Illuminate\Log\Logger;
 use Illuminate\Log\LogManager;

--- a/tests/Integration/Mail/MailFailoverTransportTest.php
+++ b/tests/Integration/Mail/MailFailoverTransportTest.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace Illuminate\Tests\Mail;
+namespace Illuminate\Tests\Integration\Mail;
 
 use Orchestra\Testbench\TestCase;
-use Symfony\Component\Mailer\Transport\RoundRobinTransport;
+use Symfony\Component\Mailer\Transport\FailoverTransport;
 
-class MailRoundRobinTransportTest extends TestCase
+class MailFailoverTransportTest extends TestCase
 {
-    public function testGetRoundRobinTransportWithConfiguredTransports(): void
+    public function testGetFailoverTransportWithConfiguredTransports(): void
     {
-        $this->app['config']->set('mail.default', 'roundrobin');
+        $this->app['config']->set('mail.default', 'failover');
 
         $this->app['config']->set('mail.mailers', [
-            'roundrobin' => [
-                'transport' => 'roundrobin',
+            'failover' => [
+                'transport' => 'failover',
                 'mailers' => [
                     'sendmail',
                     'array',
@@ -31,12 +31,12 @@ class MailRoundRobinTransportTest extends TestCase
         ]);
 
         $transport = app('mailer')->getSymfonyTransport();
-        $this->assertInstanceOf(RoundRobinTransport::class, $transport);
+        $this->assertInstanceOf(FailoverTransport::class, $transport);
     }
 
-    public function testGetRoundRobinTransportWithLaravel6StyleMailConfiguration(): void
+    public function testGetFailoverTransportWithLaravel6StyleMailConfiguration(): void
     {
-        $this->app['config']->set('mail.driver', 'roundrobin');
+        $this->app['config']->set('mail.driver', 'failover');
 
         $this->app['config']->set('mail.mailers', [
             'sendmail',
@@ -46,6 +46,6 @@ class MailRoundRobinTransportTest extends TestCase
         $this->app['config']->set('mail.sendmail', '/usr/sbin/sendmail -bs');
 
         $transport = app('mailer')->getSymfonyTransport();
-        $this->assertInstanceOf(RoundRobinTransport::class, $transport);
+        $this->assertInstanceOf(FailoverTransport::class, $transport);
     }
 }

--- a/tests/Integration/Mail/MailLogTransportTest.php
+++ b/tests/Integration/Mail/MailLogTransportTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Mail;
+namespace Illuminate\Tests\Integration\Mail;
 
 use Illuminate\Mail\Attachment;
 use Illuminate\Mail\Message;

--- a/tests/Integration/Mail/MailManagerTest.php
+++ b/tests/Integration/Mail/MailManagerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Mail;
+namespace Illuminate\Tests\Integration\Mail;
 
 use InvalidArgumentException;
 use Orchestra\Testbench\Attributes\WithConfig;

--- a/tests/Integration/Mail/MailRoundRobinTransportTest.php
+++ b/tests/Integration/Mail/MailRoundRobinTransportTest.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace Illuminate\Tests\Mail;
+namespace Illuminate\Tests\Integration\Mail;
 
 use Orchestra\Testbench\TestCase;
-use Symfony\Component\Mailer\Transport\FailoverTransport;
+use Symfony\Component\Mailer\Transport\RoundRobinTransport;
 
-class MailFailoverTransportTest extends TestCase
+class MailRoundRobinTransportTest extends TestCase
 {
-    public function testGetFailoverTransportWithConfiguredTransports(): void
+    public function testGetRoundRobinTransportWithConfiguredTransports(): void
     {
-        $this->app['config']->set('mail.default', 'failover');
+        $this->app['config']->set('mail.default', 'roundrobin');
 
         $this->app['config']->set('mail.mailers', [
-            'failover' => [
-                'transport' => 'failover',
+            'roundrobin' => [
+                'transport' => 'roundrobin',
                 'mailers' => [
                     'sendmail',
                     'array',
@@ -31,12 +31,12 @@ class MailFailoverTransportTest extends TestCase
         ]);
 
         $transport = app('mailer')->getSymfonyTransport();
-        $this->assertInstanceOf(FailoverTransport::class, $transport);
+        $this->assertInstanceOf(RoundRobinTransport::class, $transport);
     }
 
-    public function testGetFailoverTransportWithLaravel6StyleMailConfiguration(): void
+    public function testGetRoundRobinTransportWithLaravel6StyleMailConfiguration(): void
     {
-        $this->app['config']->set('mail.driver', 'failover');
+        $this->app['config']->set('mail.driver', 'roundrobin');
 
         $this->app['config']->set('mail.mailers', [
             'sendmail',
@@ -46,6 +46,6 @@ class MailFailoverTransportTest extends TestCase
         $this->app['config']->set('mail.sendmail', '/usr/sbin/sendmail -bs');
 
         $transport = app('mailer')->getSymfonyTransport();
-        $this->assertInstanceOf(FailoverTransport::class, $transport);
+        $this->assertInstanceOf(RoundRobinTransport::class, $transport);
     }
 }

--- a/tests/Integration/Mail/MarkdownParserTest.php
+++ b/tests/Integration/Mail/MarkdownParserTest.php
@@ -10,8 +10,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 class MarkdownParserTest extends TestCase
 {
-    /** {@inheritdoc} */
-    #[\Override]
     protected function tearDown(): void
     {
         Markdown::flushState();

--- a/tests/Integration/Migration/MigratorTest.php
+++ b/tests/Integration/Migration/MigratorTest.php
@@ -152,14 +152,14 @@ class MigratorTest extends TestCase
             // Returns an empty array because we are in pretend mode.
             $tablesEmpty = DB::select("SELECT name FROM sqlite_master WHERE type='table'");
 
-            $this->assertTrue([] === $tablesEmpty);
+            $this->assertSame([], $tablesEmpty);
 
             // Returns an array with two tables because we ignore pretend mode.
             $tablesList = DB::withoutPretending(function (): array {
                 return DB::select("SELECT name FROM sqlite_master WHERE type='table'");
             });
 
-            $this->assertTrue([] !== $tablesList);
+            $this->assertNotSame([], $tablesList);
 
             // The following would not be possible in pretend mode, if the
             // method DB::withoutPretending() would not exists,
@@ -171,13 +171,13 @@ class MigratorTest extends TestCase
 
                 $columnsEmpty = DB::select("PRAGMA table_info($table->name)");
 
-                $this->assertTrue([] === $columnsEmpty);
+                $this->assertSame([], $columnsEmpty);
 
                 $columnsList = DB::withoutPretending(function () use ($table): array {
                     return DB::select("PRAGMA table_info($table->name)");
                 });
 
-                $this->assertTrue([] !== $columnsList);
+                $this->assertNotSame([], $columnsList);
                 $this->assertCount(2, $columnsList);
 
                 // Confirm that we are still in pretend mode. This column should

--- a/tests/Integration/Pipeline/PipelineTransactionTest.php
+++ b/tests/Integration/Pipeline/PipelineTransactionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Pipeline;
+namespace Illuminate\Tests\Integration\Pipeline;
 
 use Exception;
 use Illuminate\Database\Events\TransactionBeginning;

--- a/tests/Integration/Queue/DebouncedJobTest.php
+++ b/tests/Integration/Queue/DebouncedJobTest.php
@@ -202,7 +202,7 @@ class DebouncedJobTest extends QueueTestCase
         $lock->release($jobA, $ownerA);
 
         // B should still be the current owner.
-        $this->assertTrue($lock->getCurrentOwner($jobB) === $ownerB);
+        $this->assertSame($lock->getCurrentOwner($jobB), $ownerB);
     }
 
     public function testReleaseClearsMaxWaitTimestamp()

--- a/tests/Integration/Queue/DeleteModelWhenMissingTest.php
+++ b/tests/Integration/Queue/DeleteModelWhenMissingTest.php
@@ -35,7 +35,6 @@ class DeleteModelWhenMissingTest extends QueueTestCase
         Schema::dropIfExists('delete_model_test_models');
     }
 
-    #[\Override]
     protected function tearDown(): void
     {
         DeleteMissingModelJob::$handled = false;

--- a/tests/Integration/Queue/DeleteNotificationWhenMissingModelTest.php
+++ b/tests/Integration/Queue/DeleteNotificationWhenMissingModelTest.php
@@ -38,7 +38,6 @@ class DeleteNotificationWhenMissingModelTest extends QueueTestCase
         Schema::dropIfExists('delete_notification_test_models');
     }
 
-    #[\Override]
     protected function tearDown(): void
     {
         DeleteWhenMissingNotification::$sent = false;

--- a/tests/Integration/Queue/FailOnExceptionMiddlewareTest.php
+++ b/tests/Integration/Queue/FailOnExceptionMiddlewareTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Queue;
+namespace Illuminate\Tests\Integration\Queue;
 
 use Illuminate\Bus\Dispatcher;
 use Illuminate\Bus\Queueable;

--- a/tests/Integration/Queue/ModelSerializationTest.php
+++ b/tests/Integration/Queue/ModelSerializationTest.php
@@ -71,7 +71,6 @@ class ModelSerializationTest extends TestCase
         });
     }
 
-    #[\Override]
     protected function tearDown(): void
     {
         Relation::morphMap([], false);

--- a/tests/Integration/Queue/QueueDelayTest.php
+++ b/tests/Integration/Queue/QueueDelayTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Queue;
+namespace Illuminate\Tests\Integration\Queue;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;

--- a/tests/Integration/Queue/QueueFakeTest.php
+++ b/tests/Integration/Queue/QueueFakeTest.php
@@ -17,25 +17,25 @@ class QueueFakeTest extends TestCase
     public function testFakeFor()
     {
         Queue::fakeFor(function () {
-            Queue::push(new TestJob);
-            Queue::assertPushed(TestJob::class);
+            Queue::push(new QueueFakeTestJob);
+            Queue::assertPushed(QueueFakeTestJob::class);
         });
     }
 
     public function testFakeExceptFor()
     {
         Queue::fakeExceptFor(function () {
-            Queue::push(new TestJob);
-            Queue::push(new OtherTestJob);
+            Queue::push(new QueueFakeTestJob);
+            Queue::push(new QueueFakeOtherTestJob);
 
-            Queue::assertNotPushed(TestJob::class);
-            Queue::assertPushed(OtherTestJob::class);
-        }, [TestJob::class]);
+            Queue::assertNotPushed(QueueFakeTestJob::class);
+            Queue::assertPushed(QueueFakeOtherTestJob::class);
+        }, [QueueFakeTestJob::class]);
     }
 
     public function testFakeExcept()
     {
-        $fake = Queue::fakeExcept([TestJob::class]);
+        $fake = Queue::fakeExcept([QueueFakeTestJob::class]);
 
         $this->assertInstanceOf(QueueFake::class, $fake);
     }
@@ -59,7 +59,7 @@ class QueueFakeTest extends TestCase
     }
 }
 
-class TestJob
+class QueueFakeTestJob
 {
     use Queueable;
 
@@ -69,7 +69,7 @@ class TestJob
     }
 }
 
-class OtherTestJob
+class QueueFakeOtherTestJob
 {
     use Queueable;
 

--- a/tests/Integration/Queue/QueueSizeTest.php
+++ b/tests/Integration/Queue/QueueSizeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Queue;
+namespace Illuminate\Tests\Integration\Queue;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;

--- a/tests/Integration/Queue/QueueTestCase.php
+++ b/tests/Integration/Queue/QueueTestCase.php
@@ -28,7 +28,6 @@ abstract class QueueTestCase extends TestCase
         $this->driver = $app['config']->get('queue.default', 'sync');
     }
 
-    #[\Override]
     protected function setUp(): void
     {
         $this->afterApplicationCreated(function () {

--- a/tests/Integration/Queue/RedisQueueTest.php
+++ b/tests/Integration/Queue/RedisQueueTest.php
@@ -33,8 +33,6 @@ class RedisQueueTest extends TestCase
      */
     private $container;
 
-    /** {@inheritdoc} */
-    #[\Override]
     protected function setUp(): void
     {
         $this->afterApplicationCreated(function () {

--- a/tests/Integration/Routing/SerializableClosureV1CacheRouteTest.php
+++ b/tests/Integration/Routing/SerializableClosureV1CacheRouteTest.php
@@ -27,8 +27,6 @@ class SerializableClosureV1CacheRouteTest extends TestCase
         ];
     }
 
-    /** {@inheritDoc} */
-    #[\Override]
     protected function setUp(): void
     {
         $_ENV['APP_ROUTES_CACHE'] = realpath(join_paths(__DIR__, 'stubs', 'serializable-closure-v1', 'routes-v7.php'));
@@ -36,8 +34,6 @@ class SerializableClosureV1CacheRouteTest extends TestCase
         parent::setUp();
     }
 
-    /** {@inheritDoc} */
-    #[\Override]
     protected function tearDown(): void
     {
         parent::tearDown();

--- a/tests/Integration/Support/StorageFacadeTest.php
+++ b/tests/Integration/Support/StorageFacadeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Support;
+namespace Illuminate\Tests\Integration\Support;
 
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Storage;

--- a/tests/Integration/Support/SupportMailTest.php
+++ b/tests/Integration/Support/SupportMailTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Support;
+namespace Illuminate\Tests\Integration\Support;
 
 use Illuminate\Mail\Mailable;
 use Illuminate\Support\Facades\Mail;

--- a/tests/Integration/Support/SupportMaintenanceModeTest.php
+++ b/tests/Integration/Support/SupportMaintenanceModeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\Support;
+namespace Illuminate\Tests\Integration\Support;
 
 use Illuminate\Contracts\Foundation\MaintenanceMode as MaintenanceModeContract;
 use Illuminate\Support\Facades\MaintenanceMode;

--- a/tests/Integration/Testing/ArtisanCommandTest.php
+++ b/tests/Integration/Testing/ArtisanCommandTest.php
@@ -213,7 +213,7 @@ class ArtisanCommandTest extends TestCase
             ->expectsOutput()
             ->assertExitCode(0);
 
-        m::close();
+        $this->verifyMockeryExpectationsNow();
     }
 
     public function test_console_command_that_fail_if_doesnt_output_something_and_is_not_the_expected_output()
@@ -264,7 +264,7 @@ class ArtisanCommandTest extends TestCase
             ->expectsConfirmation('Do you want to continue?', true)
             ->assertExitCode(0);
 
-        m::close();
+        $this->verifyMockeryExpectationsNow();
     }
 
     public function test_console_command_that_fails_if_doesnt_expect_output_but_outputs_something()
@@ -275,7 +275,7 @@ class ArtisanCommandTest extends TestCase
             ->doesntExpectOutput()
             ->assertExitCode(0);
 
-        m::close();
+        $this->verifyMockeryExpectationsNow();
     }
 
     public function test_console_command_that_fails_if_doesnt_expect_output_and_does_expect_output()
@@ -287,7 +287,7 @@ class ArtisanCommandTest extends TestCase
             ->doesntExpectOutput('My name is Taylor Otwell')
             ->assertExitCode(0);
 
-        m::close();
+        $this->verifyMockeryExpectationsNow();
     }
 
     public function test_console_command_that_fails_if_the_output_does_not_contain()
@@ -320,6 +320,15 @@ class ArtisanCommandTest extends TestCase
                 }
             })
             ->assertExitCode(0);
+    }
+
+    /**
+     * Verify the PendingCommand mock expectations immediately, so an unmet
+     * expectation throws here and is caught by the test's expectException().
+     */
+    protected function verifyMockeryExpectationsNow(): void
+    {
+        m::close();
     }
 
     /**

--- a/tests/Integration/View/BladeTest.php
+++ b/tests/Integration/View/BladeTest.php
@@ -18,8 +18,6 @@ use function Orchestra\Testbench\phpunit_version_compare;
 
 class BladeTest extends TestCase
 {
-    /** {@inheritdoc} */
-    #[\Override]
     protected function tearDown(): void
     {
         artisan($this, 'view:clear');

--- a/tests/Integration/View/ClearCommandTest.php
+++ b/tests/Integration/View/ClearCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Illuminate\Tests\View;
+namespace Illuminate\Tests\Integration\View;
 
 use Illuminate\Container\Container;
 use Illuminate\Filesystem\Filesystem;

--- a/tests/Notifications/NotificationSendQueuedNotificationTest.php
+++ b/tests/Notifications/NotificationSendQueuedNotificationTest.php
@@ -9,6 +9,7 @@ use Illuminate\Notifications\ChannelManager;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\SendQueuedNotifications;
+use Illuminate\Queue\Attributes\FailOnTimeout;
 use Illuminate\Support\Collection;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
@@ -62,6 +63,13 @@ class NotificationSendQueuedNotificationTest extends TestCase
 
         $this->assertEquals(23, $job->maxExceptions);
     }
+
+    public function testNotificationRespectsFailOnTimeoutAttribute()
+    {
+        $job = new SendQueuedNotifications(new NotifiableUser, new FailOnTimeoutNotification);
+
+        $this->assertTrue($job->failOnTimeout);
+    }
 }
 
 class NotifiableUser extends Model
@@ -73,5 +81,10 @@ class NotifiableUser extends Model
 }
 
 class TestNotification extends Notification
+{
+}
+
+#[FailOnTimeout]
+class FailOnTimeoutNotification extends Notification
 {
 }

--- a/tests/Process/ProcessTest.php
+++ b/tests/Process/ProcessTest.php
@@ -106,8 +106,8 @@ class ProcessTest extends TestCase
 
         $poolResults = $pool->wait();
 
-        $this->assertTrue($output[0]['out'] !== []);
-        $this->assertTrue($output[1]['out'] !== []);
+        $this->assertNotSame($output[0]['out'], []);
+        $this->assertNotSame($output[1]['out'], []);
         $this->assertInstanceOf(ProcessResult::class, $poolResults[0]);
         $this->assertInstanceOf(ProcessResult::class, $poolResults[1]);
         $this->assertStringContainsString('ProcessTest.php', $poolResults[0]->output());

--- a/tests/Support/LotteryTest.php
+++ b/tests/Support/LotteryTest.php
@@ -8,11 +8,6 @@ use RuntimeException;
 
 class LotteryTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        Lottery::determineResultNormally();
-    }
-
     public function testItCanWin()
     {
         $wins = false;

--- a/tests/Support/OnceTest.php
+++ b/tests/Support/OnceTest.php
@@ -9,7 +9,6 @@ class OnceTest extends TestCase
 {
     protected function tearDown(): void
     {
-        Once::flush();
         Once::enable();
     }
 

--- a/tests/Support/SleepTest.php
+++ b/tests/Support/SleepTest.php
@@ -14,11 +14,6 @@ use RuntimeException;
 
 class SleepTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        Sleep::fake(false);
-    }
-
     public function testItSleepsForSeconds()
     {
         $start = microtime(true);

--- a/tests/Support/SupportCollectionTest.php
+++ b/tests/Support/SupportCollectionTest.php
@@ -2297,8 +2297,28 @@ class SupportCollectionTest extends TestCase
     #[DataProvider('collectionClassProvider')]
     public function testFlip($collection)
     {
+        $this->assertSame([], (new $collection)->flip()->all());
+        $this->assertSame(['taylor' => 'name'], (new $collection(['name' => 'taylor']))->flip()->all());
+
         $data = new $collection(['name' => 'taylor', 'framework' => 'laravel']);
         $this->assertEquals(['taylor' => 'name', 'laravel' => 'framework'], $data->flip()->toArray());
+    }
+
+    #[DataProvider('collectionClassProvider')]
+    public function testFlipSkipsUnsupportedValues($collection)
+    {
+        $data = new $collection([
+            'string' => 'taylor',
+            'integer' => 1,
+            'null' => null,
+            'false' => false,
+            'true' => true,
+            'float' => 1.5,
+            'array' => [],
+            'object' => new stdClass,
+        ]);
+
+        $this->assertSame(['taylor' => 'string', 1 => 'integer'], @$data->flip()->all());
     }
 
     #[DataProvider('collectionClassProvider')]

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -14,13 +14,6 @@ use ValueError;
 
 class SupportStrTest extends TestCase
 {
-    /** {@inheritdoc} */
-    #[\Override]
-    protected function tearDown(): void
-    {
-        Str::createRandomStringsNormally();
-    }
-
     public function testStringCanBeLimitedByWords(): void
     {
         $this->assertSame('Taylor...', Str::words('Taylor Otwell', 1));

--- a/tests/Support/SupportStrTest.php
+++ b/tests/Support/SupportStrTest.php
@@ -1925,7 +1925,7 @@ class SupportStrTest extends TestCase
 
     public function testPasswordCreation()
     {
-        $this->assertTrue(strlen(Str::password()) === 32);
+        $this->assertSame(strlen(Str::password()), 32);
 
         $this->assertStringNotContainsString(' ', Str::password());
         $this->assertStringContainsString(' ', Str::password(spaces: true));


### PR DESCRIPTION
Trying out a composer package cache in the setup-php-project action to see if it actually speeds up CI runs. Just here to compare cold vs warm cache timings, not meant to merge as-is.